### PR TITLE
Fixing test failures on Windows

### DIFF
--- a/src/test/java/com/xebialabs/deployit/ci/FileSystemLocationTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/FileSystemLocationTest.java
@@ -35,7 +35,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -43,7 +42,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 public class FileSystemLocationTest {
-    private static final String FILE_SEPARATOR = File.separator;
 
     @Mock
     private JenkinsDeploymentListener listener;
@@ -63,7 +61,7 @@ public class FileSystemLocationTest {
     @Test
     public void shouldReturnPathWithoutChangesIfLocal() {
         FileSystemLocation fileSystemLocation = new FileSystemLocation("test.dar","./build/resources/test");
-        assertThat(fileSystemLocation.getDarFileLocation(localFilePath, listener, new EnvVars()), is(format("build%sresources%stest%stest.dar", FILE_SEPARATOR, FILE_SEPARATOR, FILE_SEPARATOR)));
+        assertThat(fileSystemLocation.getDarFileLocation(localFilePath, listener, new EnvVars()), is("build/resources/test/test.dar"));
     }
 
     @Test
@@ -84,7 +82,7 @@ public class FileSystemLocationTest {
         EnvVars envVars = new EnvVars();
         envVars.put("NAME","test");
         FileSystemLocation fileSystemLocation = new FileSystemLocation("$NAME.dar","./build/resources/test");
-        assertThat(fileSystemLocation.getDarFileLocation(localFilePath, listener, envVars), is(format("build%sresources%stest%stest.dar", FILE_SEPARATOR, FILE_SEPARATOR, FILE_SEPARATOR)));
+        assertThat(fileSystemLocation.getDarFileLocation(localFilePath, listener, envVars), is("build/resources/test/test.dar"));
 
     }
 }

--- a/src/test/java/com/xebialabs/deployit/ci/GeneratedLocationTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/GeneratedLocationTest.java
@@ -35,13 +35,11 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
 
-import static java.lang.String.format;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 public class GeneratedLocationTest {
-    private static final String FILE_SEPARATOR = File.separator;
 
     @Mock
     private JenkinsDeploymentListener listener;
@@ -63,7 +61,7 @@ public class GeneratedLocationTest {
     @Test
     public void shouldReturnPathWithoutChangesIfLocal() {
         generatedLocation.setGeneratedLocation("/tmp/test-local/asd.dar");
-        assertThat(generatedLocation.getDarFileLocation(localFilePath, listener, new EnvVars()), is(format("%stmp%stest-local%sasd.dar", FILE_SEPARATOR, FILE_SEPARATOR, FILE_SEPARATOR)));
+        assertThat(generatedLocation.getDarFileLocation(localFilePath, listener, new EnvVars()), is("/tmp/test-local/asd.dar"));
     }
 
     @Test


### PR DESCRIPTION
Example failure message:
```
    <failure message="java.lang.AssertionError: &#10;Expected: is &quot;build\resources\test\test.dar&quot;&#10;     got: &quot;build/resources/test/test.dar&quot;&#10;" type="java.lang.AssertionError">
```

@ilx @bdevic @mpvvliet: Ping?