### PR TITLE
DEPL-9295 Entries of type map_string_string can have = character

### DIFF
--- a/src/main/java/com/xebialabs/deployit/ci/server/DeployitDescriptorRegistryImpl.java
+++ b/src/main/java/com/xebialabs/deployit/ci/server/DeployitDescriptorRegistryImpl.java
@@ -26,6 +26,9 @@ package com.xebialabs.deployit.ci.server;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
 
 import javax.annotation.Nullable;
 
@@ -72,6 +75,10 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 
 public class DeployitDescriptorRegistryImpl implements DeployitDescriptorRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(DeployitDescriptorRegistryImpl.class);
+    public static final String AMP_MARKER = "::AMP::";
+    public static final String EQUAL_MARKER = "::EQUAL::";
+    public static final String AMP_ESCAPE_SEQ = "\\\\&";
+    public static final String EQUAL_ESCAPE_SEQ = "\\\\=";
     private BooterConfig booterConfig;
 
     private Monitor LOCK = new Monitor();
@@ -308,10 +315,32 @@ public class DeployitDescriptorRegistryImpl implements DeployitDescriptorRegistr
             case LIST_OF_CI:
                 return newArrayList(convertToCiRefs(val, pd));
             case MAP_STRING_STRING:
-                return Splitter.on('&').withKeyValueSeparator("=").split(val);
+                return convertToMap(val);
             default:
                 return val;
         }
+    }
+
+    protected Map convertToMap(String val) {
+        val = replaceEscapedCharactersWithMarkers(val);
+        Map<String,String> values = Splitter.on('&').withKeyValueSeparator("=").split(val);
+        return Collections.unmodifiableMap(replaceMarkersWithEscapedCharacters(values));
+    }
+
+    private Map<String, String> replaceMarkersWithEscapedCharacters(Map<String, String> values) {
+        Map<String,String> map = new HashMap<String, String>();
+        for(Map.Entry<String,String> entry : values.entrySet()) {
+            map.put(replaceMarkers(entry.getKey()), replaceMarkers(entry.getValue()));
+        }
+        return map;
+    }
+
+    private String replaceEscapedCharactersWithMarkers(String val) {
+        return val.replaceAll(AMP_ESCAPE_SEQ, AMP_MARKER).replaceAll(EQUAL_ESCAPE_SEQ, EQUAL_MARKER);
+    }
+
+    private String replaceMarkers(String val) {
+        return val.replaceAll(AMP_MARKER, "&").replaceAll(EQUAL_MARKER, "=");
     }
 
     private Iterable<ConfigurationItem> convertToCiRefs(String val, final PropertyDescriptor pd) {

--- a/src/main/markdown/jenkinsPluginManual.markdown
+++ b/src/main/markdown/jenkinsPluginManual.markdown
@@ -60,6 +60,10 @@ If you practice continuous delivery, it may be useful to increase the version au
 
 If you have many deployment jobs running in parallel you can tweak the connection settings by increasing the connection pool size on the Global configuration screen. The default connection pool size is 10.
 
+**Escape '&' and '=' characters in a property of type map_string_string**
+
+A '&' and '='can be escaped with sequence '\&' and '\=' respectively, for example string a=1&b=2&c=abc=xyz&d=a&b can be replaced with a=1&b=2&c=abc\=xyz&d=a\&b
+
 ## Release notes ##
 
 ### Version 5.0.0 ##
@@ -83,7 +87,7 @@ Improvements:
 * [DEPL-7400] - Allow XLD credentials to be overridden in a Jenkins job
 
 Bug fixes:
-    
+
 * [DEPL-7184] - Publish DAR fails in mixed windows/unix master/slave setup
 * [DEPL-7254] - File system location doesn't support referencing file on Jenkins slave
 

--- a/src/test/java/com/xebialabs/deployit/ci/server/DeployitDescriptorRegistrySetPropertyTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/server/DeployitDescriptorRegistrySetPropertyTest.java
@@ -1,0 +1,62 @@
+package com.xebialabs.deployit.ci.server;
+
+import com.xebialabs.deployit.booter.remote.BooterConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class DeployitDescriptorRegistrySetPropertyTest {
+
+    @Mock
+    private BooterConfig booterConfig;
+
+    private DeployitDescriptorRegistryImpl deployitDescriptorRegistry;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        deployitDescriptorRegistry = new DeployitDescriptorRegistryImpl(booterConfig);
+    }
+
+    @Test
+    public void shouldReturnMapWithKeyValueWithNoSpecialCharacter() {
+        String testValue = "key1=value1&key2=value2&key3=value3";
+        Map<String, String> returnedMap = (Map<String, String>) deployitDescriptorRegistry.convertToMap(testValue);
+        assertThat(returnedMap.size(), is(3));
+        assertMapKeyValues("key1", "value1", returnedMap);
+        assertMapKeyValues("key2", "value2", returnedMap);
+        assertMapKeyValues("key3", "value3", returnedMap);
+    }
+
+    private void assertMapKeyValues(String testKey, String testValue, Map<String, String> map) {
+        assertTrue(map.containsKey(testKey));
+        assertThat(map.get(testKey), is(testValue));
+    }
+
+    @Test
+    public void shouldReturnMapWithKeyValueWithSpecialCharacter() {
+        String testValue = "key1\\&key11=value1&key2=value2\\=value22&key3=value3";
+        Map<String, String> returnedMap = (Map<String, String>) deployitDescriptorRegistry.convertToMap(testValue);
+        assertThat(returnedMap.size(), is(3));
+        assertMapKeyValues("key1&key11", "value1", returnedMap);
+        assertMapKeyValues("key2", "value2=value22", returnedMap);
+        assertMapKeyValues("key3", "value3", returnedMap);
+    }
+
+    @Test
+    public void shouldReturnMapWithKeyValueWithNoValues() {
+        String testValue = "key1\\&key11=\\=value1&key2=value2\\=value22&key3=";
+        Map<String, String> returnedMap = (Map<String, String>) deployitDescriptorRegistry.convertToMap(testValue);
+        assertThat(returnedMap.size(), is(3));
+        assertMapKeyValues("key1&key11", "=value1", returnedMap);
+        assertMapKeyValues("key2", "value2=value22", returnedMap);
+        assertMapKeyValues("key3", "", returnedMap);
+    }
+}


### PR DESCRIPTION
- If CI properties of type map_string_string has keys/ values with characters ('&' or '='), the same will be escaped while constructing map object.