### PR TITLE
DEPL-12107 - Error when Jenkins uses Oracle Java 8u144

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ configurations {
 }
 
 ext {
-    xlPlatformVersion = "2016.2.1"
+    xlPlatformVersion = "2016.2.6"
 
 }
 


### PR DESCRIPTION
DEPL-12107 - Error with Oracle java when testing connection to XLD. Updated latest released platform dependency. Scannit v1.4.0 was causing the error- checked after updating scannit to v1.4.1.