### PR TITLE
Fix for casting MavenModuleSet to Project

### DIFF
--- a/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
@@ -108,7 +108,7 @@ public class DeployitNotifier extends Notifier {
 
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        Project context = (Project) build.getProject();
+        AbstractProject context = (AbstractProject) build.getProject();
         DeployitServer deployitServer = RepositoryUtils.getDeployitServer(credential, overridingCredential, context);
         DeployitPerformerParameters performerParameters = new DeployitPerformerParameters(packageOptions, packageProperties, importOptions, deploymentOptions, application, version, verbose);
         DeployitPerformer performer = new DeployitPerformer(build, launcher, listener, deployitServer, performerParameters);


### PR DESCRIPTION
When using a Maven project in Jenkins; this plugin failed. This change make it possible for MavenModuleSet to use the XLDeploy plugin again. Without this change the plugin failed with:

```
java.lang.ClassCastException: hudson.maven.MavenModuleSet cannot be cast to hudson.model.Project
	at com.xebialabs.deployit.ci.DeployitNotifier.perform(DeployitNotifier.java:111)
	at hudson.tasks.BuildStepMonitor$3.perform(BuildStepMonitor.java:45)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.post2(MavenModuleSetBuild.java:1073)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
	at hudson.model.Run.execute(Run.java:1841)
	at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:543)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```

With this change, `hudson.maven.MavenModuleSet` is casted to `hudson.maven.AbstractProject`, which is a parent of `hudson.maven.MavenModuleSet`.  It seems that `hudson.model.Project` is not a parent of `hudson.maven.MavenModuleSet`.