### PR TITLE
ENG-6465 Automatically reload deploy types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,9 +117,9 @@ configurations {
     testCompile.exclude group: 'org.netbeans.modules', module: "org-netbeans-insane"
     providedRuntime.exclude group: 'ch.qos.logback', module: 'logback-classic'
     providedRuntime.exclude group: 'ch.qos.logback', module: 'logback-core'
-    providedRuntime.exclude group: 'org.slf4j', module: 'slf4j-api'
     providedRuntime.exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
     providedRuntime.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
+
     slf4j
 }
 
@@ -165,6 +165,7 @@ dependencies {
     testCompile "org.jenkins-ci.plugins.workflow:workflow-job:1.10@jar"
     testCompile "org.jenkins-ci.plugins.workflow:workflow-cps:1.10@jar"
     testCompile "org.jenkins-ci.plugins.workflow:workflow-api:1.10@jar"
+    testCompile "org.slf4j:slf4j-api:1.7.7"
 
     jenkinsTest("org.jenkins-ci.plugins.workflow:workflow-step-api:1.10@hpi") { transitive = true }
     jenkinsTest("org.jenkins-ci.plugins.workflow:workflow-support:1.10@hpi") { transitive = true }

--- a/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
@@ -75,15 +75,24 @@ public class DeployitNotifier extends Notifier {
     public final JenkinsImportOptions importOptions;
     public final JenkinsDeploymentOptions deploymentOptions;
     public final boolean verbose;
+    public final boolean reloadDeployTypes;
 
     public Credential overridingCredential;
 
     public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties) {
-        this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, null);
+        this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, null, false);
+    }
+
+    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, boolean reloadDeployTypes) {
+        this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, null, reloadDeployTypes);
+    }
+
+    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, Credential overridingCredential) {
+        this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, overridingCredential, false);
     }
 
     @DataBoundConstructor
-    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, Credential overridingCredential) {
+    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, Credential overridingCredential, boolean reloadDeployTypes) {
         this.credential = credential;
         this.application = application;
         this.version = version;
@@ -93,6 +102,7 @@ public class DeployitNotifier extends Notifier {
         this.verbose = verbose;
         this.packageProperties = packageProperties;
         this.overridingCredential = overridingCredential;
+        this.reloadDeployTypes = reloadDeployTypes;
         PluginLogger.getInstance().setVerbose(verbose);
     }
 
@@ -103,7 +113,6 @@ public class DeployitNotifier extends Notifier {
 
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-
         if (credential != null) {
             String cred = credential;
             Credential credential = RepositoryUtils.findCredential(cred);
@@ -118,7 +127,7 @@ public class DeployitNotifier extends Notifier {
 
             DeployitServer deployitServer = descriptor.getDeployitServer(credential, build.getProject());
 
-            DeployitPerformerParameters performerParameters = new DeployitPerformerParameters(packageOptions, packageProperties, importOptions, deploymentOptions, application, version, verbose);
+            DeployitPerformerParameters performerParameters = new DeployitPerformerParameters(packageOptions, packageProperties, importOptions, deploymentOptions, application, version, verbose, reloadDeployTypes);
 
             DeployitPerformer performer = new DeployitPerformer(build, listener, deployitServer, performerParameters);
 
@@ -378,7 +387,6 @@ public class DeployitNotifier extends Notifier {
 
         @RequirePOST
         public FormValidation doReloadTypes(@QueryParameter String credential, @AncestorInPath AbstractProject project) {
-
             project.checkPermission(Item.CONFIGURE);
             Credential overridingcredential = RepositoryUtils.retrieveOverridingCredentialFromProject(project);
             try {

--- a/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
@@ -75,7 +75,7 @@ public class DeployitNotifier extends Notifier {
     public final JenkinsImportOptions importOptions;
     public final JenkinsDeploymentOptions deploymentOptions;
     public final boolean verbose;
-    public final boolean reloadDeployTypes;
+    public final boolean loadTypesOnStartup;
 
     public Credential overridingCredential;
 
@@ -83,8 +83,8 @@ public class DeployitNotifier extends Notifier {
         this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, null, false);
     }
 
-    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, boolean reloadDeployTypes) {
-        this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, null, reloadDeployTypes);
+    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, boolean loadTypesOnStartup) {
+        this(credential, application, version, packageOptions, importOptions, deploymentOptions, verbose, packageProperties, null, loadTypesOnStartup);
     }
 
     public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, Credential overridingCredential) {
@@ -92,7 +92,7 @@ public class DeployitNotifier extends Notifier {
     }
 
     @DataBoundConstructor
-    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, Credential overridingCredential, boolean reloadDeployTypes) {
+    public DeployitNotifier(String credential, String application, String version, JenkinsPackageOptions packageOptions, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions, boolean verbose, List<PackageProperty> packageProperties, Credential overridingCredential, boolean loadTypesOnStartup) {
         this.credential = credential;
         this.application = application;
         this.version = version;
@@ -102,7 +102,7 @@ public class DeployitNotifier extends Notifier {
         this.verbose = verbose;
         this.packageProperties = packageProperties;
         this.overridingCredential = overridingCredential;
-        this.reloadDeployTypes = reloadDeployTypes;
+        this.loadTypesOnStartup = loadTypesOnStartup;
         PluginLogger.getInstance().setVerbose(verbose);
     }
 
@@ -127,7 +127,7 @@ public class DeployitNotifier extends Notifier {
 
             DeployitServer deployitServer = descriptor.getDeployitServer(credential, build.getProject());
 
-            DeployitPerformerParameters performerParameters = new DeployitPerformerParameters(packageOptions, packageProperties, importOptions, deploymentOptions, application, version, verbose, reloadDeployTypes);
+            DeployitPerformerParameters performerParameters = new DeployitPerformerParameters(packageOptions, packageProperties, importOptions, deploymentOptions, application, version, verbose, loadTypesOnStartup);
 
             DeployitPerformer performer = new DeployitPerformer(build, listener, deployitServer, performerParameters);
 

--- a/src/main/java/com/xebialabs/deployit/ci/DeployitPerformer.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitPerformer.java
@@ -45,6 +45,9 @@ class DeployitPerformer {
     }
 
     public boolean doPerform() throws InterruptedException, IOException {
+        if (deploymentParameters.reloadDeployTypes) {
+            deployitServer.reload();
+        }
         final EnvVars envVars = build.getEnvironment(buildListener);
         String resolvedApplication = envVars.expand(deploymentParameters.application);
 
@@ -171,6 +174,7 @@ class DeployitPerformer {
         public String application;
         public String version;
         public boolean verbose;
+        public boolean reloadDeployTypes;
 
         public DeployitPerformerParameters(JenkinsPackageOptions packageOptions, List<PackageProperty> packageProperties, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions,
             String application, String version, boolean verbose) {
@@ -181,6 +185,18 @@ class DeployitPerformer {
             this.application = application;
             this.version = version;
             this.verbose = verbose;
+            this.reloadDeployTypes = false;
+        }
+        public DeployitPerformerParameters(JenkinsPackageOptions packageOptions, List<PackageProperty> packageProperties, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions,
+                                           String application, String version, boolean verbose, boolean reloadDeployTypes) {
+            this.packageOptions = packageOptions;
+            this.packageProperties = packageProperties;
+            this.importOptions = importOptions;
+            this.deploymentOptions = deploymentOptions;
+            this.application = application;
+            this.version = version;
+            this.verbose = verbose;
+            this.reloadDeployTypes = reloadDeployTypes;
         }
     }
 }

--- a/src/main/java/com/xebialabs/deployit/ci/DeployitPerformer.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitPerformer.java
@@ -45,7 +45,7 @@ class DeployitPerformer {
     }
 
     public boolean doPerform() throws InterruptedException, IOException {
-        if (deploymentParameters.reloadDeployTypes) {
+        if (deploymentParameters.loadTypesOnStartup) {
             deployitServer.reload();
         }
         final EnvVars envVars = build.getEnvironment(buildListener);
@@ -174,7 +174,7 @@ class DeployitPerformer {
         public String application;
         public String version;
         public boolean verbose;
-        public boolean reloadDeployTypes;
+        public boolean loadTypesOnStartup;
 
         public DeployitPerformerParameters(JenkinsPackageOptions packageOptions, List<PackageProperty> packageProperties, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions,
             String application, String version, boolean verbose) {
@@ -185,10 +185,10 @@ class DeployitPerformer {
             this.application = application;
             this.version = version;
             this.verbose = verbose;
-            this.reloadDeployTypes = false;
+            this.loadTypesOnStartup = false;
         }
         public DeployitPerformerParameters(JenkinsPackageOptions packageOptions, List<PackageProperty> packageProperties, JenkinsImportOptions importOptions, JenkinsDeploymentOptions deploymentOptions,
-                                           String application, String version, boolean verbose, boolean reloadDeployTypes) {
+                                           String application, String version, boolean verbose, boolean loadTypesOnStartup) {
             this.packageOptions = packageOptions;
             this.packageProperties = packageProperties;
             this.importOptions = importOptions;
@@ -196,7 +196,7 @@ class DeployitPerformer {
             this.application = application;
             this.version = version;
             this.verbose = verbose;
-            this.reloadDeployTypes = reloadDeployTypes;
+            this.loadTypesOnStartup = loadTypesOnStartup;
         }
     }
 }

--- a/src/main/resources/com/xebialabs/deployit/ci/DeployitNotifier/config.jelly
+++ b/src/main/resources/com/xebialabs/deployit/ci/DeployitNotifier/config.jelly
@@ -30,7 +30,7 @@
         </f:optionalBlock>
     </f:block>
 
-    <f:entry title="${%Reload types automatically}" field="reloadDeployTypes">
+    <f:entry title="${%Load types automatically}" field="loadTypesOnStartup">
        <f:checkbox />
     </f:entry>
 

--- a/src/main/resources/com/xebialabs/deployit/ci/DeployitNotifier/config.jelly
+++ b/src/main/resources/com/xebialabs/deployit/ci/DeployitNotifier/config.jelly
@@ -30,6 +30,10 @@
         </f:optionalBlock>
     </f:block>
 
+    <f:entry title="${%Reload types automatically}" field="reloadDeployTypes">
+       <f:checkbox />
+    </f:entry>
+
 
     <f:validateButton title="${%Reload types for credential}" with="credential" method="reloadTypes" />
 

--- a/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
@@ -68,7 +68,7 @@ public class RepositoryUtilsTest {
 
 
     @Test
-    public void shouldReloadWhenEnabled() throws Exception {
+    public void shouldRetrieveLoadTypesFlag() throws Exception {
         Folder f = r.jenkins.createProject(Folder.class, "folder-relead");
         FreeStyleProject freeStyleProjectSpy = spy(new FreeStyleProject(f, "folder-reload/proj1"));
 
@@ -82,7 +82,7 @@ public class RepositoryUtilsTest {
         doReturn(publisherListMock).when(freeStyleProjectSpy).getPublishersList();
 
         assertNotNull(RepositoryUtils.retrieveDeployitNotifierFromProject(freeStyleProjectSpy));
-        assertEquals(RepositoryUtils.retrieveDeployitNotifierFromProject(freeStyleProjectSpy).reloadDeployTypes, true);
+        assertEquals(RepositoryUtils.retrieveDeployitNotifierFromProject(freeStyleProjectSpy).loadTypesOnStartup, true);
     }
 
 

--- a/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
@@ -17,6 +17,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -64,6 +65,26 @@ public class RepositoryUtilsTest {
 
         assertNull(RepositoryUtils.retrieveOverridingCredentialFromProject(freeStyleProjectSpy));
     }
+
+
+    @Test
+    public void shouldReloadWhenEnabled() throws Exception {
+        Folder f = r.jenkins.createProject(Folder.class, "folder-relead");
+        FreeStyleProject freeStyleProjectSpy = spy(new FreeStyleProject(f, "folder-reload/proj1"));
+
+        DeployitNotifier.DeployitDescriptor descriptor = new DeployitNotifier.DeployitDescriptor();
+        DeployitNotifier notifierSpy = spy(new DeployitNotifier("AdminGlobal2", "app1", null, null, null, null, false, null, true));
+        doReturn(descriptor).when(notifierSpy).getDescriptor();
+        freeStyleProjectSpy.addPublisher(notifierSpy);
+
+        DescribableList<Publisher, Descriptor<Publisher>> publisherListMock = mock(DescribableList.class);
+        doReturn(notifierSpy).when(publisherListMock).get(any(DeployitNotifier.DeployitDescriptor.class));
+        doReturn(publisherListMock).when(freeStyleProjectSpy).getPublishersList();
+
+        assertNotNull(RepositoryUtils.retrieveDeployitNotifierFromProject(freeStyleProjectSpy));
+        assertEquals(RepositoryUtils.retrieveDeployitNotifierFromProject(freeStyleProjectSpy).reloadDeployTypes, true);
+    }
+
 
     CredentialsStore getFolderStore(Folder f) {
         Iterable<CredentialsStore> stores = CredentialsProvider.lookupStores(f);


### PR DESCRIPTION
Story: https://digitalai.atlassian.net/browse/ENG-6465
Add a checkbox in plugin configure section.
If enabled the types from deploy server will be auto loaded so
that on every restart or whenever a mismatch is there the jobs doesn't
require manual intervention.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
