### PR TITLE
Fix Xstream forbidden access issue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,15 +1,13 @@
 | Plugin Information                                                                                              |
 |-----------------------------------------------------------------------------------------------------------------|
-| View XebiaLabs XL Deploy [on the plugin site](https://plugins.jenkins.io/deployit-plugin) for more information. |
-
 Older versions of this plugin may not be safe to use. Please review the
 following warnings before using an older version:
 
 -   [CSRF vulnerability and missing permission check allow
     SSRF](https://jenkins.io/security/advisory/2019-04-17/#SECURITY-983)
 
-The XL Deploy Plugin integrates Jenkins with [XebiaLabs XL
-Deploy](https://xebialabs.com/products/xl-deploy) by adding three
+The Digital.ai Deploy Plugin integrates Jenkins with [Digital.ai
+Deploy](https://docs.digital.ai/bundle/devops-deploy-version-v.10.2) by adding three
 post-build actions to your Jenkins installation:
 
 -   Package your application
@@ -20,8 +18,8 @@ These actions can be executed separately or combined sequentially.
 
 # Requirements
 
--   XL Deploy versions supported: from 9.5.1 to 10.1.0
--   Jenkins LTS versions supported: from 2.60.1 to 2.277.2
+-   Digital.ai Deploy versions supported: from 9.7.x to 10.3.x
+-   Jenkins LTS versions supported: from 2.289.1 to 2.303.3
 -   Java 8
 
 **Note:** In version 6.0.0 and later, the plugin requires the Jenkins
@@ -42,5 +40,5 @@ or later.
     (supported in version 6.1.0 and later)
 
 For information about configuring and using the plugin, visit the
-[XebiaLabs documentation
+[Digital.ai documentation
 site](https://docs.xebialabs.com/deploy/concept/jenkins-xl-deploy-plugin.html).

--- a/src/main/java/com/xebialabs/xltype/serialization/xstream/XStreamReaderWriter.java
+++ b/src/main/java/com/xebialabs/xltype/serialization/xstream/XStreamReaderWriter.java
@@ -85,7 +85,7 @@ public class XStreamReaderWriter implements MessageBodyReader<Object>, MessageBo
 
     protected void init() {
         xStream.allowTypes(new Class[] {
-            com.xebialabs.deployit.engine.api.dto.Deployment.class
+            Deployment.class
         });
         Collection<Converter> converters = allConverters();
         for (Converter converter : converters) {

--- a/src/main/java/com/xebialabs/xltype/serialization/xstream/XStreamReaderWriter.java
+++ b/src/main/java/com/xebialabs/xltype/serialization/xstream/XStreamReaderWriter.java
@@ -62,6 +62,7 @@ import com.thoughtworks.xstream.io.xml.XppDriver;
 import com.xebialabs.deployit.plugin.api.reflect.Descriptor;
 import com.xebialabs.deployit.plugin.api.reflect.DescriptorRegistry;
 import com.xebialabs.deployit.plugin.api.udm.ConfigurationItem;
+import com.xebialabs.deployit.engine.api.dto.Deployment;
 
 import nl.javadude.scannit.Scannit;
 
@@ -83,6 +84,9 @@ public class XStreamReaderWriter implements MessageBodyReader<Object>, MessageBo
     }
 
     protected void init() {
+        xStream.allowTypes(new Class[] {
+            com.xebialabs.deployit.engine.api.dto.Deployment.class
+        });
         Collection<Converter> converters = allConverters();
         for (Converter converter : converters) {
             registerConverter(converter);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-66927
Latest version of jenkins bumped xstream library from version 1.4.17 to 1.4.18. that creates a following exception.
com.thoughtworks.xstream.security.ForbiddenClassException: com.xebialabs.deployit.engine.api.dto.Deployment
    at com.thoughtworks.xstream.security.NoTypePermission.allows(NoTypePermission.java:26)

Resolved the issue by adding the allowedType Deployment class for Xstream security

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

test has been done with different versions of jenkins.
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
