### PR TITLE
ENG-8029:Change the provider class name and add the required exemptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,7 @@ configurations {
 }
 
 ext {
-    xlPlatformVersion = "2016.2.6"
-
+    xlPlatformVersion = "10.0.8"
 }
 
 dependencies {

--- a/src/main/java/com/xebialabs/deployit/ci/dar/RemotePackaging.java
+++ b/src/main/java/com/xebialabs/deployit/ci/dar/RemotePackaging.java
@@ -37,6 +37,9 @@ import com.xebialabs.deployit.plugin.api.reflect.Descriptor;
 import com.xebialabs.deployit.plugin.api.reflect.DescriptorRegistry;
 import com.xebialabs.deployit.plugin.api.udm.DeploymentPackage;
 import org.jenkinsci.remoting.RoleChecker;
+import scala.Function0;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * Wrapper for the packaging operation.
@@ -50,7 +53,7 @@ public class RemotePackaging implements Callable<String, RuntimeException> {
     private BooterConfig booterConfig;
     private Collection<Descriptor> descriptors;
     private String registryVersion;
-
+    private Function0<MessageDigest> messageDigest;
 
     public RemotePackaging forDeploymentPackage(DeploymentPackage deploymentPackage) {
         this.deploymentPackage = deploymentPackage;
@@ -81,10 +84,15 @@ public class RemotePackaging implements Callable<String, RuntimeException> {
      * Call to be executed via jenkins virtual channel
      */
     @Override
-    public String call() throws RuntimeException {
+    public String call() throws RuntimeException  {
         targetDir.mkdirs();
         ManifestWriter mw = new ManifestXmlWriter();
-        DarPackager pkger = new DarPackager(mw);
+        try {
+            messageDigest = (Function0<MessageDigest>) MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e){
+            System.out.println(e);
+        }
+        DarPackager pkger = new DarPackager(mw,messageDigest);
         DescriptorRegistry descriptorRegistry = DescriptorRegistry.getDescriptorRegistry(booterConfig);
         if (null == descriptorRegistry) {
            SlaveRemoteDescriptorRegistry.boot(descriptors, booterConfig, registryVersion);

--- a/src/main/java/com/xebialabs/deployit/ci/dar/RemotePackaging.java
+++ b/src/main/java/com/xebialabs/deployit/ci/dar/RemotePackaging.java
@@ -40,6 +40,8 @@ import org.jenkinsci.remoting.RoleChecker;
 import scala.Function0;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper for the packaging operation.
@@ -54,6 +56,7 @@ public class RemotePackaging implements Callable<String, RuntimeException> {
     private Collection<Descriptor> descriptors;
     private String registryVersion;
     private Function0<MessageDigest> messageDigest;
+    private static final Logger logger = LoggerFactory.getLogger(RemotePackaging.class);
 
     public RemotePackaging forDeploymentPackage(DeploymentPackage deploymentPackage) {
         this.deploymentPackage = deploymentPackage;
@@ -84,13 +87,13 @@ public class RemotePackaging implements Callable<String, RuntimeException> {
      * Call to be executed via jenkins virtual channel
      */
     @Override
-    public String call() throws RuntimeException  {
+    public String call() throws RuntimeException {
         targetDir.mkdirs();
         ManifestWriter mw = new ManifestXmlWriter();
         try {
             messageDigest = (Function0<MessageDigest>) MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e){
-            System.out.println(e);
+            logger.info(e.getMessage());
         }
         DarPackager pkger = new DarPackager(mw,messageDigest);
         DescriptorRegistry descriptorRegistry = DescriptorRegistry.getDescriptorRegistry(booterConfig);

--- a/src/main/java/com/xebialabs/xltype/serialization/xstream/XStreamReaderWriterJenkins.java
+++ b/src/main/java/com/xebialabs/xltype/serialization/xstream/XStreamReaderWriterJenkins.java
@@ -62,6 +62,8 @@ import com.thoughtworks.xstream.io.xml.XppDriver;
 import com.xebialabs.deployit.plugin.api.reflect.Descriptor;
 import com.xebialabs.deployit.plugin.api.reflect.DescriptorRegistry;
 import com.xebialabs.deployit.plugin.api.udm.ConfigurationItem;
+import com.xebialabs.deployit.engine.api.dto.Deployment;
+import com.xebialabs.deployit.engine.api.dto.ConfigurationItemId;
 
 import nl.javadude.scannit.Scannit;
 
@@ -72,17 +74,20 @@ import nl.javadude.scannit.Scannit;
 @Provider
 @Produces({"application/*+xml", "text/*+xml"})
 @Consumes({"application/*+xml", "text/*+xml"})
-public class XStreamReaderWriter implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
+public class XStreamReaderWriterJenkins implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
     public static final XppDriver HIERARCHICAL_STREAM_DRIVER = new XppDriver(new XmlFriendlyNameCoder("_-", "_"));
     private static final XStream xStream = new XStreamWithoutReflectionConverter(HIERARCHICAL_STREAM_DRIVER);
     private static final AtomicReference<List<Converter>> CONVERTERS = new AtomicReference<List<Converter>>(Lists.<Converter>newArrayList());
 
-    public XStreamReaderWriter() {
-        logger.debug("Created XStreamReaderWriter");
+    public XStreamReaderWriterJenkins() {
+        logger.debug("Created XStreamReaderWriterJenkins");
         init();
     }
 
     protected void init() {
+        xStream.allowTypes(new Class[] {
+                Deployment.class , ConfigurationItemId.class
+        });
         Collection<Converter> converters = allConverters();
         for (Converter converter : converters) {
             registerConverter(converter);
@@ -188,7 +193,7 @@ public class XStreamReaderWriter implements MessageBodyReader<Object>, MessageBo
         return xStream.unmarshal(HIERARCHICAL_STREAM_DRIVER.createReader(entityStream), null, dataHolder);
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(XStreamReaderWriter.class);
+    private static final Logger logger = LoggerFactory.getLogger(XStreamReaderWriterJenkins.class);
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {


### PR DESCRIPTION
[<!-- Please describe your pull request here. -->](https://issues.jenkins.io/browse/JENKINS-66927
Latest version of jenkins bumped xstream library from version 1.4.17 to 1.4.18. that creates a following exception.
com.thoughtworks.xstream.security.ForbiddenClassException: com.xebialabs.deployit.engine.api.dto.Deployment
at com.thoughtworks.xstream.security.NoTypePermission.allows(NoTypePermission.java:26)

We have 2 XstreamReaderWriter in the Classpath and is getting from the former classpath, have renamed it to have Jenkins suffix. And have also added the permission for the 2 files for which the error is occuring.

Also updated the XL platform version to the last version of a platform which is compiled by JDK 8 (10.0.8)

Also similar PR is earlier raised , If this fix works , we can close the below PR accordingly.

https://github.com/jenkinsci/xldeploy-plugin/pull/83

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
