### PR TITLE
FI-1049: Connection Pool Error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     compile "com.xebialabs.deployit.engine:packager:$xlPlatformVersion"
     compile "com.xebialabs.deployit:engine-api:$xlPlatformVersion"
     // The Remote Booter 10.0.13 is not Released , so using a local plugin (Please Download and build the remote-booter from xl-platform-10.0.x-maintanance), In future remove this and replace with released version.
-    //compile "com.xebialabs.deployit.engine:remote-booter:$xlPlatformVersio"
+    //compile "com.xebialabs.deployit.engine:remote-booter:$xlPlatformVersion"
     compile "com.xebialabs.deployit.engine:remote-booter:10.0.13-SNAPSHOT"
     compile "org.jdom:jdom2:2.0.5"
     provided 'org.slf4j:slf4j-api:1.7.7'

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ localizer.dependsOn deleteGeneratedSrcLocalizer
 repositories {
     mavenCentral()
     jcenter()
+	mavenLocal()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "http://repo.jenkins-ci.org/releases" }
     maven { url "http://www.knopflerfish.org/maven2" }
@@ -54,6 +55,7 @@ buildscript {
         // Maven repository, but has dependencies in Maven Central.
         mavenCentral()
         jcenter()
+		mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "http://repo.jenkins-ci.org/releases" }
         maven { url "http://www.knopflerfish.org/maven2" }
@@ -129,7 +131,8 @@ ext {
 dependencies {
     compile "com.xebialabs.deployit.engine:packager:$xlPlatformVersion"
     compile "com.xebialabs.deployit:engine-api:$xlPlatformVersion"
-    compile "com.xebialabs.deployit.engine:remote-booter:$xlPlatformVersion"
+    // The Remote Booter 10.0.13 is not Released , so using a local plugin (Please Download and build the remote-booter from xl-platform), In future remove this and replace with released version.
+	compile "com.xebialabs.deployit.engine:remote-booter:10.0.13-SNAPSHOT"
     compile "org.jdom:jdom2:2.0.5"
     provided 'org.slf4j:slf4j-api:1.7.7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ localizer.dependsOn deleteGeneratedSrcLocalizer
 repositories {
     mavenCentral()
     jcenter()
-	mavenLocal()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "http://repo.jenkins-ci.org/releases" }
     maven { url "http://www.knopflerfish.org/maven2" }
@@ -55,7 +54,6 @@ buildscript {
         // Maven repository, but has dependencies in Maven Central.
         mavenCentral()
         jcenter()
-		mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "http://repo.jenkins-ci.org/releases" }
         maven { url "http://www.knopflerfish.org/maven2" }

--- a/build.gradle
+++ b/build.gradle
@@ -129,8 +129,9 @@ ext {
 dependencies {
     compile "com.xebialabs.deployit.engine:packager:$xlPlatformVersion"
     compile "com.xebialabs.deployit:engine-api:$xlPlatformVersion"
-    // The Remote Booter 10.0.13 is not Released , so using a local plugin (Please Download and build the remote-booter from xl-platform), In future remove this and replace with released version.
-	compile "com.xebialabs.deployit.engine:remote-booter:10.0.13-SNAPSHOT"
+    // The Remote Booter 10.0.13 is not Released , so using a local plugin (Please Download and build the remote-booter from xl-platform-10.0.x-maintanance), In future remove this and replace with released version.
+    //compile "com.xebialabs.deployit.engine:remote-booter:$xlPlatformVersio"
+    compile "com.xebialabs.deployit.engine:remote-booter:10.0.13-SNAPSHOT"
     compile "org.jdom:jdom2:2.0.5"
     provided 'org.slf4j:slf4j-api:1.7.7'
 


### PR DESCRIPTION
https://digitalai.atlassian.net/browse/FI-1049

When Jenkins tries to deploy it failed (it can happen randomly) and gives the timeout connection pool as below error but it managed to complete successfully from XL Deploy with no error: Timeout waiting for connection from pool

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
