### PR TITLE
fix(D-42819): handle getSteps() failure gracefully on distributed XLD workers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.xebialabs.deployit.ci
-version = 24.3.0-SNAPSHOT
+version = 24.3.1-SNAPSHOT
 description = Package and deploy your applications from Jenkins with &lt;a href='http://www.xebialabs.com'&gt;XebiaLabs XL Deploy&lt;/a&gt;.
 languageLevel=1.8

--- a/src/main/java/com/xebialabs/deployit/ci/server/DeployCommand.java
+++ b/src/main/java/com/xebialabs/deployit/ci/server/DeployCommand.java
@@ -217,24 +217,25 @@ public class DeployCommand {
         }
 
         StringBuilder sb = new StringBuilder();
-        int stepCount = 0;
-        for (StepState stepInfo : taskService.getSteps(taskId).getSteps()) {
-
-            final String description = stepInfo.getDescription();
-            final String log = stepInfo.getLog();
-            String stepInfoMessage;
-            if (StringUtils.isEmpty(log) || description.equals(log)) {
-                stepInfoMessage = format("%s step #%d %s\t%s", taskId, stepCount, stepInfo.getState(), description);
-            } else {
-                stepInfoMessage = format("%s step #%d %s\t%s\n%s", taskId, stepCount, stepInfo.getState(), description, log);
+        try {
+            int stepCount = 0;
+            for (StepState stepInfo : taskService.getSteps(taskId).getSteps()) {
+                final String description = stepInfo.getDescription();
+                final String log = stepInfo.getLog();
+                String stepInfoMessage;
+                if (StringUtils.isEmpty(log) || description.equals(log)) {
+                    stepInfoMessage = format("%s step #%d %s\t%s", taskId, stepCount, stepInfo.getState(), description);
+                } else {
+                    stepInfoMessage = format("%s step #%d %s\t%s\n%s", taskId, stepCount, stepInfo.getState(), description, log);
+                }
+                listener.info(stepInfoMessage);
+                if (StepExecutionState.FAILED.equals(stepInfo.getState()))
+                    sb.append(stepInfoMessage);
+                stepCount++;
             }
-
-            listener.info(stepInfoMessage);
-            if (StepExecutionState.FAILED.equals(stepInfo.getState()))
-                sb.append(stepInfoMessage);
-            stepCount++;
+        } catch (Exception e) {
+            listener.info(format("Could not retrieve step details for task %s: %s", taskId, e.getMessage()));
         }
-
         if (taskState.getState().isExecutionHalted())
             throw new DeployitPluginException(format("Errors when executing task %s: %s", taskId, sb));
     }


### PR DESCRIPTION
## Problem

In XLD 25.x distributed cluster deployments, the plugin triggers a spurious rollback even when all deployment steps complete successfully.

**Root cause:** After `startTaskAndWait()` exits (task reached `EXECUTED`), the plugin calls `checkTaskState()` for post-execution logging. Inside that method, two separate REST calls are made:

1. `GET /deployit/task/{id}` (`getTask`) — succeeds, answered from the master's task registry cache
2. `GET /deployit/task/{id}/step` (`getSteps`) — **throws an exception**

In a distributed XLD cluster, step-level Pekko actors on the worker node are stopped as part of normal task completion at `EXECUTED` state. By the time the plugin calls `getSteps()`, those actors are gone. The worker returns an error, which the REST client surfaces as a `RuntimeException`.

This exception propagates out of `checkTaskState()` into `executeTask()`'s catch block, which incorrectly interprets it as a deployment failure and triggers a rollback. The `archive()` call is never reached.

This is an architecture mismatch: `engine-api` (v10) was designed for single-JVM XLD where both `getTask()` and `getSteps()` were local calls. In modern distributed XLD, only `getTask()` is answered from the master's cached state — `getSteps()` requires a live round-trip to the worker node.

**Confirmed on:** XLD 25.1.1 with 2-worker cluster.

## Fix

`getSteps()` is used solely for logging step details. The actual pass/fail decision is driven by `isExecutionHalted()` on the `taskState` returned by `getTask()`, which is unaffected.

A failure in `getSteps()` must not be treated as a deployment failure. The fix wraps the `getSteps()` call and step-iteration loop in a non-fatal `try/catch`. On failure, a warning is logged and execution continues to `archive()`.

**File changed:** `src/main/java/com/xebialabs/deployit/ci/server/DeployCommand.java` — `checkTaskState()` method only.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| Successful deployment on distributed worker | Spurious rollback triggered | Deployment succeeds, step detail warning logged |
| Failed deployment | Rollback triggered correctly | Rollback triggered correctly (unchanged) |
| Single-JVM / older XLD | Works correctly | Works correctly (unchanged) |