### PR TITLE
S-124965: Jenkins Deploy Plugin: Support PAT in Deploy Connection

### DIFF
--- a/src/main/java/com/xebialabs/deployit/ci/Credential.java
+++ b/src/main/java/com/xebialabs/deployit/ci/Credential.java
@@ -28,14 +28,15 @@ import static hudson.util.FormValidation.error;
 import static hudson.util.FormValidation.ok;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
-import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
 import com.google.common.base.Function;
@@ -59,6 +60,11 @@ import jenkins.model.Jenkins;
 
 public class Credential extends AbstractDescribableImpl<Credential> {
 
+    public enum AuthType {
+        BASIC,
+        PAT
+    }
+
     public static final Function<Credential, String> CREDENTIAL_INDEX = new Function<Credential, String>() {
         @Override
         public String apply(Credential input) {
@@ -68,9 +74,11 @@ public class Credential extends AbstractDescribableImpl<Credential> {
     private final String name;
     private final String username;
     private final Secret password;
+    private final Secret patToken;
     private final String credentialsId;
     private final boolean useGlobalCredential;
     private final SecondaryServerInfo secondaryServerInfo;
+    private final AuthType authType;
 
     private static final SchemeRequirement HTTP_SCHEME = new SchemeRequirement("http");
     private static final SchemeRequirement HTTPS_SCHEME = new SchemeRequirement("https");
@@ -78,13 +86,28 @@ public class Credential extends AbstractDescribableImpl<Credential> {
     private static final Logger LOGGER = Logger.getLogger(Credential.class.getName());
 
     @DataBoundConstructor
-    public Credential(String name, String username, Secret password, String credentialsId, SecondaryServerInfo secondaryServerInfo, boolean useGlobalCredential) {
+    public Credential(String name, String username, Secret password, Secret patToken, String credentialsId, SecondaryServerInfo secondaryServerInfo, boolean useGlobalCredential, String authType) {
         this.name = name;
         this.username = username;
         this.password = password;
+        this.patToken = patToken;
         this.credentialsId = credentialsId;
         this.secondaryServerInfo = secondaryServerInfo;
         this.useGlobalCredential = useGlobalCredential;
+
+        AuthType resolvedAuthType = AuthType.BASIC;
+        if (!Strings.isNullOrEmpty(authType)) {
+            try {
+                resolvedAuthType = AuthType.valueOf(authType);
+            } catch (IllegalArgumentException ignored) {
+                resolvedAuthType = AuthType.BASIC;
+            }
+        }
+        this.authType = resolvedAuthType;
+    }
+
+    public Credential(String name, String username, Secret password, Secret patToken, String credentialsId, SecondaryServerInfo secondaryServerInfo, boolean useGlobalCredential) {
+        this(name, username, password, patToken, credentialsId, secondaryServerInfo, useGlobalCredential, AuthType.BASIC.toString());
     }
 
     public String getCredentialsId() {
@@ -92,7 +115,19 @@ public class Credential extends AbstractDescribableImpl<Credential> {
     }
 
     public String getKey() {
-        return username + ":" + password.getPlainText() + "@" + name + ":" + credentialsId + ":";
+        return username + ":" + password.getPlainText() + "@" + name + ":" + credentialsId + ":" + authType;
+    }
+
+    public String getAuthType() {
+        return authType.toString();
+    }
+
+    public boolean isBasicAuth() {
+        return authType == AuthType.BASIC;
+    }
+
+    public boolean isPAT() {
+        return authType == AuthType.PAT;
     }
 
     public String getName() {
@@ -107,6 +142,17 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         return password;
     }
 
+    public Secret getPatToken() {
+        return patToken;
+    }
+
+    public Secret getEffectivePassword() {
+        if (isPAT()) {
+            return patToken != null ? patToken : password;
+        }
+        return password;
+    }
+
     public boolean isUseGlobalCredential() {
         return useGlobalCredential;
     }
@@ -114,11 +160,17 @@ public class Credential extends AbstractDescribableImpl<Credential> {
     public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Project context) {
         // TODO: also add requirement on host derived from URL ?
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-        List<StandardUsernamePasswordCredentials> creds = lookupCredentials(StandardUsernamePasswordCredentials.class, context,
+        List<IdCredentials> creds = lookupCredentials(IdCredentials.class, context,
                 ACL.SYSTEM,
                 HTTP_SCHEME, HTTPS_SCHEME);
 
-        return new StandardUsernameListBoxModel().withAll(creds);
+        ListBoxModel model = new ListBoxModel();
+        for (IdCredentials cred : creds) {
+            if (cred instanceof StandardUsernamePasswordCredentials || isSecretTextCredential(cred)) {
+                model.add(credentialDisplayName(cred), cred.getId());
+            }
+        }
+        return model;
     }
 
     public String getSecondaryServerUrl() {
@@ -174,6 +226,7 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         if (secondaryServerInfo == null && that.secondaryServerInfo != null) return false;
         if (secondaryServerInfo != null && !secondaryServerInfo.equals(that.secondaryServerInfo)) return false;
         if (useGlobalCredential && that.useGlobalCredential && !credentialsId.equals(that.credentialsId)) return false;
+        if (authType != that.authType) return false;
         return username.equals(that.username);
     }
 
@@ -184,6 +237,7 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         result = 31 * result + (password != null ? password.hashCode() : 0);
         result = 31 * result + (useGlobalCredential && credentialsId != null ? credentialsId.hashCode() : 0);
         result = 31 * result + (secondaryServerInfo != null ? secondaryServerInfo.hashCode() : 0);
+        result = 31 * result + (authType != null ? authType.hashCode() : 0);
         return result;
     }
 
@@ -257,6 +311,17 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         return result;
     }
 
+    public static IdCredentials lookupSystemIdCredentials(String credentialsId, ItemGroup<?> item) {
+        if (credentialsId == null) {
+            return null;
+        }
+
+        return CredentialsMatchers.firstOrNull(
+                lookupCredentials(IdCredentials.class, item, ACL.SYSTEM, HTTP_SCHEME, HTTPS_SCHEME),
+                CredentialsMatchers.withId(credentialsId)
+        );
+    }
+
     @Extension
     public static final class CredentialDescriptor extends Descriptor<Credential> {
         @Override
@@ -267,11 +332,18 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Project context) {
             // TODO: also add requirement on host derived from URL ?
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-            List<StandardUsernamePasswordCredentials> creds = lookupCredentials(StandardUsernamePasswordCredentials.class, context,
+            List<IdCredentials> creds = lookupCredentials(IdCredentials.class, context,
                     ACL.SYSTEM,
                     HTTP_SCHEME, HTTPS_SCHEME);
 
-            return new StandardUsernameListBoxModel().withAll(creds);
+            ListBoxModel model = new ListBoxModel();
+            for (IdCredentials cred : creds) {
+                if (cred instanceof StandardUsernamePasswordCredentials || isSecretTextCredential(cred)) {
+                    model.add(credentialDisplayName(cred), cred.getId());
+                }
+            }
+
+            return model;
         }
 
         private FormValidation validateOptionalUrl(String url) {
@@ -293,15 +365,15 @@ public class Credential extends AbstractDescribableImpl<Credential> {
             return validateOptionalUrl(secondaryProxyUrl);
         }
 
-        public static Credential fromStapler(@QueryParameter String name, @QueryParameter String username, @QueryParameter Secret password,
+        public static Credential fromStapler(@QueryParameter String name, @QueryParameter String username, @QueryParameter Secret password, @QueryParameter Secret patToken,
                                              @QueryParameter String deployitServerUrl, @QueryParameter String deployitClientProxyUrl,
-                                             @QueryParameter String secondaryServerUrl, @QueryParameter String secondaryProxyUrl, @QueryParameter String credentialsId, @QueryParameter boolean useGlobalCredential) {
+                                             @QueryParameter String secondaryServerUrl, @QueryParameter String secondaryProxyUrl, @QueryParameter String credentialsId, @QueryParameter boolean useGlobalCredential, @QueryParameter String authType) {
 
-            return new Credential(name, username, password, credentialsId, new SecondaryServerInfo(secondaryServerUrl, secondaryProxyUrl), useGlobalCredential);
+            return new Credential(name, username, password, patToken, credentialsId, new SecondaryServerInfo(secondaryServerUrl, secondaryProxyUrl), useGlobalCredential, authType);
         }
 
         public FormValidation doValidateUserNamePassword(@QueryParameter String deployitServerUrl, @QueryParameter String deployitClientProxyUrl, @QueryParameter String username,
-                                                         @QueryParameter Secret password, @QueryParameter String secondaryServerUrl, @QueryParameter String secondaryProxyUrl) throws IOException {
+                                                         @QueryParameter Secret password, @QueryParameter Secret patToken, @QueryParameter String secondaryServerUrl, @QueryParameter String secondaryProxyUrl, @QueryParameter String authType) throws IOException {
             try {
                 String serverUrl = Strings.isNullOrEmpty(secondaryServerUrl) ? deployitServerUrl : secondaryServerUrl;
                 String proxyUrl = Strings.isNullOrEmpty(secondaryProxyUrl) ? deployitClientProxyUrl : secondaryProxyUrl;
@@ -310,7 +382,19 @@ public class Credential extends AbstractDescribableImpl<Credential> {
                     return FormValidation.error("No server URL specified");
                 }
 
-                return validateConnection(serverUrl, proxyUrl, username, password.getPlainText());
+                String effectiveUsername = username;
+                if (!Strings.isNullOrEmpty(authType) && AuthType.PAT.name().equals(authType)) {
+                    effectiveUsername = "";
+                }
+
+                Secret effectivePassword = !Strings.isNullOrEmpty(authType) && AuthType.PAT.name().equals(authType)
+                    ? patToken : password;
+
+                if (effectivePassword == null) {
+                    return FormValidation.error("No password or PAT token specified");
+                }
+
+                return validateConnection(serverUrl, proxyUrl, effectiveUsername, effectivePassword.getPlainText());
             } catch (IllegalStateException e) {
                 return FormValidation.error(e.getMessage());
             } catch (Exception e) {
@@ -319,7 +403,7 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         }
 
         @RequirePOST
-        public FormValidation doValidateCredential(@QueryParameter String deployitServerUrl, @QueryParameter String deployitClientProxyUrl, @QueryParameter String secondaryServerUrl, @QueryParameter String secondaryProxyUrl, @QueryParameter String credentialsId) throws IOException {
+        public FormValidation doValidateCredential(@QueryParameter String deployitServerUrl, @QueryParameter String deployitClientProxyUrl, @QueryParameter String secondaryServerUrl, @QueryParameter String secondaryProxyUrl, @QueryParameter String credentialsId, @QueryParameter String authType) throws IOException {
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
             try {
 
@@ -329,15 +413,36 @@ public class Credential extends AbstractDescribableImpl<Credential> {
                 if (Strings.isNullOrEmpty(credentialsId)) {
                     return FormValidation.error("No credentials specified");
                 }
-                StandardUsernamePasswordCredentials credentials = lookupSystemCredentials(credentialsId);
+                IdCredentials idCredentials = lookupSystemIdCredentials(credentialsId);
 
-                if (credentials == null) {
+                if (idCredentials == null) {
                     return FormValidation.error(String.format("Could not find credential with id '%s'", credentialsId));
                 }
                 if (Strings.isNullOrEmpty(serverUrl)) {
                     return FormValidation.error("No server URL specified");
                 }
-                return validateConnection(serverUrl, proxyUrl, credentials.getUsername(), credentials.getPassword().getPlainText());
+
+                String effectiveUsername;
+                String effectivePassword;
+                if (!Strings.isNullOrEmpty(authType) && AuthType.PAT.name().equals(authType)) {
+                    if (!isSecretTextCredential(idCredentials)) {
+                        return FormValidation.error("For PAT authentication, select a Secret Text credential.");
+                    }
+                    effectiveUsername = "";
+                    effectivePassword = extractTokenValue(idCredentials);
+                    if (Strings.isNullOrEmpty(effectivePassword)) {
+                        return FormValidation.error("Selected credential does not provide a token value for PAT authentication.");
+                    }
+                } else {
+                    if (!(idCredentials instanceof StandardUsernamePasswordCredentials)) {
+                        return FormValidation.error("Selected credential must be Username with password for BASIC authentication.");
+                    }
+                    StandardUsernamePasswordCredentials credentials = (StandardUsernamePasswordCredentials) idCredentials;
+                    effectiveUsername = credentials.getUsername();
+                    effectivePassword = credentials.getPassword().getPlainText();
+                }
+
+                return validateConnection(serverUrl, proxyUrl, effectiveUsername, effectivePassword);
             } catch (IllegalStateException e) {
                 return FormValidation.error(e.getMessage());
             } catch (Exception e) {
@@ -361,12 +466,70 @@ public class Credential extends AbstractDescribableImpl<Credential> {
             );
         }
 
+                public static IdCredentials lookupSystemIdCredentials(String credentialsId) {
+                    if (credentialsId == null) {
+                    return null;
+                    }
+
+                    return CredentialsMatchers.firstOrNull(
+                        lookupCredentials(IdCredentials.class,
+                            Jenkins.getInstance(),
+                            ACL.SYSTEM,
+                            HTTP_SCHEME,
+                            HTTPS_SCHEME),
+                        CredentialsMatchers.withId(credentialsId)
+                    );
+                }
+
         private FormValidation validateConnection(String serverUrl, String proxyUrl, String username, String password) throws Exception {
             DeployitServer deployitServer = DeployitServerFactory.newInstance(serverUrl, proxyUrl, username, password, 10, DeployitServer.DEFAULT_SOCKET_TIMEOUT);
             ServerInfo serverInfo = deployitServer.getServerInfo();
             deployitServer.newCommunicator();
             return FormValidation.ok("Your XL Deploy instance [%s] is alive, and your credentials are valid!", serverInfo.getVersion());
         }
+    }
+
+    private static String credentialDisplayName(IdCredentials cred) {
+        if (cred instanceof StandardUsernamePasswordCredentials) {
+            StandardUsernamePasswordCredentials userPass = (StandardUsernamePasswordCredentials) cred;
+            return userPass.getUsername() + " (" + userPass.getId() + ")";
+        }
+        return cred.getId();
+    }
+
+    public static boolean isSecretTextCredential(IdCredentials credential) {
+        if (credential == null) {
+            return false;
+        }
+
+        try {
+            Method method = credential.getClass().getMethod("getSecret");
+            return Secret.class.isAssignableFrom(method.getReturnType());
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    public static String extractTokenValue(IdCredentials credential) {
+        if (credential == null) {
+            return null;
+        }
+
+        if (credential instanceof StandardUsernamePasswordCredentials) {
+            return ((StandardUsernamePasswordCredentials) credential).getPassword().getPlainText();
+        }
+
+        try {
+            Method method = credential.getClass().getMethod("getSecret");
+            Object value = method.invoke(credential);
+            if (value instanceof Secret) {
+                return ((Secret) value).getPlainText();
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+
+        return null;
     }
 
 }

--- a/src/main/java/com/xebialabs/deployit/ci/Credential.java
+++ b/src/main/java/com/xebialabs/deployit/ci/Credential.java
@@ -115,7 +115,9 @@ public class Credential extends AbstractDescribableImpl<Credential> {
     }
 
     public String getKey() {
-        return username + ":" + password.getPlainText() + "@" + name + ":" + credentialsId + ":" + authType;
+        Secret effective = getEffectivePassword();
+        String secretPart = effective != null ? effective.toString() : "";
+        return username + ":" + secretPart + "@" + name + ":" + credentialsId + ":" + authType;
     }
 
     public String getAuthType() {
@@ -222,7 +224,9 @@ public class Credential extends AbstractDescribableImpl<Credential> {
         final Credential that = (Credential) o;
 
         if (!name.equals(that.name)) return false;
-        if (!password.equals(that.password)) return false;
+        Secret thisEffective = getEffectivePassword();
+        Secret thatEffective = that.getEffectivePassword();
+        if (thisEffective == null ? thatEffective != null : !thisEffective.equals(thatEffective)) return false;
         if (secondaryServerInfo == null && that.secondaryServerInfo != null) return false;
         if (secondaryServerInfo != null && !secondaryServerInfo.equals(that.secondaryServerInfo)) return false;
         if (useGlobalCredential && that.useGlobalCredential && !credentialsId.equals(that.credentialsId)) return false;
@@ -234,7 +238,8 @@ public class Credential extends AbstractDescribableImpl<Credential> {
     public int hashCode() {
         int result = name.hashCode();
         result = 31 * result + (username != null ? username.hashCode() : 0);
-        result = 31 * result + (password != null ? password.hashCode() : 0);
+        Secret effectivePassword = getEffectivePassword();
+        result = 31 * result + (effectivePassword != null ? effectivePassword.hashCode() : 0);
         result = 31 * result + (useGlobalCredential && credentialsId != null ? credentialsId.hashCode() : 0);
         result = 31 * result + (secondaryServerInfo != null ? secondaryServerInfo.hashCode() : 0);
         result = 31 * result + (authType != null ? authType.hashCode() : 0);
@@ -413,7 +418,7 @@ public class Credential extends AbstractDescribableImpl<Credential> {
                 if (Strings.isNullOrEmpty(credentialsId)) {
                     return FormValidation.error("No credentials specified");
                 }
-                IdCredentials idCredentials = lookupSystemIdCredentials(credentialsId);
+                IdCredentials idCredentials = Credential.lookupSystemIdCredentials(credentialsId, Jenkins.getInstance());
 
                 if (idCredentials == null) {
                     return FormValidation.error(String.format("Could not find credential with id '%s'", credentialsId));
@@ -465,21 +470,6 @@ public class Credential extends AbstractDescribableImpl<Credential> {
                     CredentialsMatchers.withId(credentialsId)
             );
         }
-
-                public static IdCredentials lookupSystemIdCredentials(String credentialsId) {
-                    if (credentialsId == null) {
-                    return null;
-                    }
-
-                    return CredentialsMatchers.firstOrNull(
-                        lookupCredentials(IdCredentials.class,
-                            Jenkins.getInstance(),
-                            ACL.SYSTEM,
-                            HTTP_SCHEME,
-                            HTTPS_SCHEME),
-                        CredentialsMatchers.withId(credentialsId)
-                    );
-                }
 
         private FormValidation validateConnection(String serverUrl, String proxyUrl, String username, String password) throws Exception {
             DeployitServer deployitServer = DeployitServerFactory.newInstance(serverUrl, proxyUrl, username, password, 10, DeployitServer.DEFAULT_SOCKET_TIMEOUT);

--- a/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
@@ -23,8 +23,8 @@
 
 package com.xebialabs.deployit.ci;
 
-import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
 import com.google.common.base.Strings;
 import com.xebialabs.deployit.ci.DeployitPerformer.DeployitPerformerParameters;
@@ -181,14 +181,39 @@ public class DeployitNotifier extends Notifier {
             int newSocketTimeout = socketTimeout > 0 ? socketTimeout : DeployitServer.DEFAULT_SOCKET_TIMEOUT;
 
             String userName = credential.getUsername();
-            String password = credential.getPassword().getPlainText();
+            String password = credential.getEffectivePassword() != null ? credential.getEffectivePassword().getPlainText() : null;
+
+            if (credential.isPAT()) {
+                userName = "";
+            }
+
+            if (Strings.isNullOrEmpty(password)) {
+                throw new IllegalArgumentException(String.format("Credentials for '%s' do not contain a password or PAT token.", credential.getName()));
+            }
+
             if (credential.isUseGlobalCredential()) {
-                StandardUsernamePasswordCredentials cred = Credential.lookupSystemCredentials(credential.getCredentialsId(), itemGroup);
-                if (cred == null) {
+                IdCredentials idCred = Credential.lookupSystemIdCredentials(credential.getCredentialsId(), itemGroup);
+                if (idCred == null) {
                     throw new IllegalArgumentException(String.format("Credentials for '%s' not found.", credential.getCredentialsId()));
                 }
-                userName = cred.getUsername();
-                password = cred.getPassword().getPlainText();
+
+                if (credential.isPAT()) {
+                    if (!Credential.isSecretTextCredential(idCred)) {
+                        throw new IllegalArgumentException(String.format("Credentials for '%s' must be Secret Text for PAT authentication.", credential.getCredentialsId()));
+                    }
+                    userName = "";
+                    password = Credential.extractTokenValue(idCred);
+                    if (Strings.isNullOrEmpty(password)) {
+                        throw new IllegalArgumentException(String.format("Credentials for '%s' do not provide a token value.", credential.getCredentialsId()));
+                    }
+                } else {
+                    if (!(idCred instanceof StandardUsernamePasswordCredentials)) {
+                        throw new IllegalArgumentException(String.format("Credentials for '%s' must be Username with password for BASIC authentication.", credential.getCredentialsId()));
+                    }
+                    StandardUsernamePasswordCredentials cred = (StandardUsernamePasswordCredentials) idCred;
+                    userName = cred.getUsername();
+                    password = cred.getPassword().getPlainText();
+                }
             }
             return DeployitServerFactory.newInstance(serverUrl, proxyUrl, userName, password, newConnectionPoolSize, newSocketTimeout);
         }
@@ -374,10 +399,17 @@ public class DeployitNotifier extends Notifier {
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
             Jenkins.getInstance().checkPermission(Jenkins.READ);
-            List<StandardUsernamePasswordCredentials> creds = lookupCredentials(StandardUsernamePasswordCredentials.class, context,
+            List<IdCredentials> creds = lookupCredentials(IdCredentials.class, context,
                     ACL.SYSTEM,
                     HTTP_SCHEME, HTTPS_SCHEME);
-            return new StandardUsernameListBoxModel().withAll(creds);
+
+            ListBoxModel model = new ListBoxModel();
+            for (IdCredentials cred : creds) {
+                if (cred instanceof StandardUsernamePasswordCredentials || Credential.isSecretTextCredential(cred)) {
+                    model.add(cred.getId(), cred.getId());
+                }
+            }
+            return model;
         }
 
         @RequirePOST

--- a/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
+++ b/src/main/java/com/xebialabs/deployit/ci/DeployitNotifier.java
@@ -181,15 +181,7 @@ public class DeployitNotifier extends Notifier {
             int newSocketTimeout = socketTimeout > 0 ? socketTimeout : DeployitServer.DEFAULT_SOCKET_TIMEOUT;
 
             String userName = credential.getUsername();
-            String password = credential.getEffectivePassword() != null ? credential.getEffectivePassword().getPlainText() : null;
-
-            if (credential.isPAT()) {
-                userName = "";
-            }
-
-            if (Strings.isNullOrEmpty(password)) {
-                throw new IllegalArgumentException(String.format("Credentials for '%s' do not contain a password or PAT token.", credential.getName()));
-            }
+            String password;
 
             if (credential.isUseGlobalCredential()) {
                 IdCredentials idCred = Credential.lookupSystemIdCredentials(credential.getCredentialsId(), itemGroup);
@@ -213,6 +205,14 @@ public class DeployitNotifier extends Notifier {
                     StandardUsernamePasswordCredentials cred = (StandardUsernamePasswordCredentials) idCred;
                     userName = cred.getUsername();
                     password = cred.getPassword().getPlainText();
+                }
+            } else {
+                if (credential.isPAT()) {
+                    userName = "";
+                }
+                password = credential.getEffectivePassword() != null ? credential.getEffectivePassword().getPlainText() : null;
+                if (Strings.isNullOrEmpty(password)) {
+                    throw new IllegalArgumentException(String.format("Credentials for '%s' do not contain a password or PAT token.", credential.getName()));
                 }
             }
             return DeployitServerFactory.newInstance(serverUrl, proxyUrl, userName, password, newConnectionPoolSize, newSocketTimeout);

--- a/src/main/java/com/xebialabs/deployit/ci/RepositoryUtils.java
+++ b/src/main/java/com/xebialabs/deployit/ci/RepositoryUtils.java
@@ -54,7 +54,7 @@ public class RepositoryUtils {
         String secondaryProxyUrl = credential.resolveProxyUrl(descriptor.getDeployitClientProxyUrl());
         String secondaryServerUrl = credential.resolveServerUrl(descriptor.getDeployitServerUrl());
         SecondaryServerInfo serverInfo = new SecondaryServerInfo(secondaryServerUrl, secondaryProxyUrl);
-        credential = new Credential(name, username, password, credentialId, serverInfo, useGlobalCredential);
+        credential = new Credential(name, username, password, null, credentialId, serverInfo, useGlobalCredential);
         return credential;
     }
 
@@ -85,7 +85,7 @@ public class RepositoryUtils {
 
                 StandardUsernamePasswordCredentials cred = Credential.lookupSystemCredentials(overridingCredential.getCredentialsId(), project.getParent());
                 if (null != cred) {
-                    overridingCredential = new Credential(overridingCredential.getName(), cred.getUsername(), cred.getPassword(),
+                        overridingCredential = new Credential(overridingCredential.getName(), cred.getUsername(), cred.getPassword(), null,
                             overridingCredential.getCredentialsId(), serverInfo, false);
                 }
             }

--- a/src/main/resources/com/xebialabs/deployit/ci/Credential/config.jelly
+++ b/src/main/resources/com/xebialabs/deployit/ci/Credential/config.jelly
@@ -14,7 +14,7 @@
         </f:optionalBlock>
         <f:entry title="${%Authentication Type}" field="authType">
             <f:radio name="authType" value="BASIC" checked="${instance.isBasicAuth() || !instance.isPAT()}" title="Basic Username/Password"/>
-            <f:radio name="authType" value="PAT" checked="${instance.isPAT()}" title="Personal Access Token (PAT)"/>
+            <f:radio name="authType" value="PAT" checked="${instance.isPAT()}" title="Personal Access Token"/>
         </f:entry>
         <f:radioBlock inline="true" name="useGlobalCredential" value="false" title="Use inline credentials" checked="${!instance.showGolbalCredentials()}">
             <div id="xld-basic-inline-fields">
@@ -28,7 +28,7 @@
                                   method="validateUserNamePassword"/>
             </div>
             <div id="xld-pat-inline-fields">
-                <f:entry title="${%Personal Access Token}" field="patToken">
+                <f:entry title="${%Token}" field="patToken">
                     <f:password/>
                 </f:entry>
                 <f:validateButton title="${%Test Credential}" with="deployitServerUrl,deployitClientProxyUrl,patToken,secondaryServerUrl,secondaryProxyUrl,authType"

--- a/src/main/resources/com/xebialabs/deployit/ci/Credential/config.jelly
+++ b/src/main/resources/com/xebialabs/deployit/ci/Credential/config.jelly
@@ -12,23 +12,169 @@
                 <f:textbox/>
             </f:entry>
         </f:optionalBlock>
-        <f:radioBlock inline="true" name="useGlobalCredential" value="false" title="Use username/password" checked="${!instance.showGolbalCredentials()}">
-            <f:entry title="${%Username}" field="username">
-                <f:textbox/>
-            </f:entry>
-            <f:entry title="${%Password}" field="password">
-                <f:password/>
-            </f:entry>
-            <f:validateButton title="${%Test Credential}" with="deployitServerUrl,deployitClientProxyUrl,username,password,secondaryServerUrl,secondaryProxyUrl"
-                              method="validateUserNamePassword"/>
+        <f:entry title="${%Authentication Type}" field="authType">
+            <f:radio name="authType" value="BASIC" checked="${instance.isBasicAuth() || !instance.isPAT()}" title="Basic Username/Password"/>
+            <f:radio name="authType" value="PAT" checked="${instance.isPAT()}" title="Personal Access Token (PAT)"/>
+        </f:entry>
+        <f:radioBlock inline="true" name="useGlobalCredential" value="false" title="Use inline credentials" checked="${!instance.showGolbalCredentials()}">
+            <div id="xld-basic-inline-fields">
+                <f:entry title="${%Username}" field="username">
+                    <f:textbox/>
+                </f:entry>
+                <f:entry title="${%Password}" field="password">
+                    <f:password/>
+                </f:entry>
+                <f:validateButton title="${%Test Credential}" with="deployitServerUrl,deployitClientProxyUrl,username,password,secondaryServerUrl,secondaryProxyUrl,authType"
+                                  method="validateUserNamePassword"/>
+            </div>
+            <div id="xld-pat-inline-fields">
+                <f:entry title="${%Personal Access Token}" field="patToken">
+                    <f:password/>
+                </f:entry>
+                <f:validateButton title="${%Test Credential}" with="deployitServerUrl,deployitClientProxyUrl,patToken,secondaryServerUrl,secondaryProxyUrl,authType"
+                                  method="validateUserNamePassword"/>
+            </div>
         </f:radioBlock>
         <f:radioBlock inline="true" name="useGlobalCredential" value="true" title="Use stored credentials" checked="${instance.showGolbalCredentials()}">
             <f:entry title="${%Credentials}" field="credentialsId">
                 <c:select/>
             </f:entry>
-            <f:validateButton title="${%Test Connection}" with="deployitServerUrl,deployitClientProxyUrl,secondaryServerUrl,secondaryProxyUrl,credentialsId"
+            <f:validateButton title="${%Test Connection}" with="deployitServerUrl,deployitClientProxyUrl,secondaryServerUrl,secondaryProxyUrl,credentialsId,authType"
                               method="validateCredential"/>
         </f:radioBlock>
         <f:description><br/></f:description>
+        <script type="text/javascript"><![CDATA[
+            (function() {
+                // Returns matching inputs for a logical field suffix, preferring radio controls.
+                function radioInputsBySuffix(nameSuffix) {
+                    var inputs = document.getElementsByTagName("input");
+                    var radioMatches = [];
+                    var otherMatches = [];
+
+                    function nameMatches(inputName, suffix) {
+                        if (!inputName) {
+                            return false;
+                        }
+                        if (inputName === suffix) {
+                            return true;
+                        }
+
+                        var boundaryPattern = new RegExp("(^|[._\\[\\]-])" + suffix + "($|[._\\]\\[])");
+                        return boundaryPattern.test(inputName) || inputName.indexOf(suffix) >= 0;
+                    }
+
+                    for (var i = 0; i < inputs.length; i++) {
+                        var input = inputs[i];
+                        var inputName = input.name || "";
+                        if (!nameMatches(inputName, nameSuffix)) {
+                            continue;
+                        }
+
+                        if (input.type === "radio") {
+                            radioMatches.push(input);
+                        } else {
+                            otherMatches.push(input);
+                        }
+                    }
+
+                    var matches = radioMatches.length > 0 ? radioMatches : otherMatches;
+
+                    return matches;
+                }
+
+                // Gets the selected value from a radio-like control group by suffix.
+                function checkedRadioValue(nameSuffix) {
+                    var radios = radioInputsBySuffix(nameSuffix);
+                    for (var i = 0; i < radios.length; i++) {
+                        if (radios[i].checked) {
+                            return radios[i].value;
+                        }
+                    }
+
+                    // Some Jenkins controls can render as non-radio inputs.
+                    if (radios.length === 1 && typeof radios[0].value !== "undefined") {
+                        return radios[0].value;
+                    }
+
+                    return null;
+                }
+
+                // Shows or hides a section and disables inactive inputs to prevent form over-posting.
+                function toggleSection(sectionId, isVisible) {
+                    var section = document.getElementById(sectionId);
+                    if (!section) {
+                        return;
+                    }
+
+                    section.style.display = isVisible ? "block" : "none";
+                    var fields = section.getElementsByTagName("input");
+                    for (var i = 0; i < fields.length; i++) {
+                        fields[i].disabled = !isVisible;
+                    }
+                }
+
+                // Cross-browser event binding wrapper for modern and legacy Jenkins UIs.
+                function bindEvent(target, eventName, legacyEventName, handler) {
+                    if (!target) {
+                        return;
+                    }
+
+                    if (target.addEventListener) {
+                        target.addEventListener(eventName, handler);
+                    } else if (target.attachEvent) {
+                        target.attachEvent(legacyEventName, handler);
+                    }
+                }
+
+                // Computes and applies inline credential visibility for BASIC vs PAT modes.
+                function refreshCredentialVisibility() {
+                    var authType = checkedRadioValue("authType");
+                    var useGlobalCredential = checkedRadioValue("useGlobalCredential");
+
+                    // Safe defaults: show BASIC inline fields when controls are not discoverable.
+                    if (authType === null) {
+                        authType = "BASIC";
+                    }
+
+                    if (useGlobalCredential === null) {
+                        useGlobalCredential = "false";
+                    }
+
+                    var useInlineCredentials = useGlobalCredential !== "true";
+                    var usePat = authType === "PAT";
+
+                    toggleSection("xld-basic-inline-fields", useInlineCredentials && !usePat);
+                    toggleSection("xld-pat-inline-fields", useInlineCredentials && usePat);
+                }
+
+                // Binds change listeners once per discovered control group.
+                function wireEvents(nameSuffix) {
+                    var radios = radioInputsBySuffix(nameSuffix);
+                    for (var i = 0; i < radios.length; i++) {
+                        if (radios[i]._xldToggleBound) {
+                            continue;
+                        }
+
+                        radios[i]._xldToggleBound = true;
+                        bindEvent(radios[i], "change", "onchange", refreshCredentialVisibility);
+                    }
+                }
+
+                // Performs initial wiring and first-pass visibility refresh.
+                function initializeCredentialToggle() {
+                    wireEvents("authType");
+                    wireEvents("useGlobalCredential");
+                    refreshCredentialVisibility();
+                }
+
+                if (document.readyState === "loading") {
+                    bindEvent(document, "DOMContentLoaded", "onreadystatechange", initializeCredentialToggle);
+                } else {
+                    initializeCredentialToggle();
+                }
+
+                bindEvent(window, "load", "onload", initializeCredentialToggle);
+            })();
+        ]]></script>
     </f:block>
 </j:jelly>

--- a/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
+++ b/src/test/java/com/xebialabs/deployit/ci/RepositoryUtilsTest.java
@@ -38,7 +38,7 @@ public class RepositoryUtilsTest {
         getFolderStore(f).addCredentials(Domain.global(), credentials);
 
         // Matches what's sent from ui
-        Credential overridingCredentialProvided = new Credential(null, "", null, credentials.getId(), null, true);
+        Credential overridingCredentialProvided = new Credential(null, "", null, null, credentials.getId(), null, true);
         DeployitNotifier.DeployitDescriptor descriptor = new DeployitNotifier.DeployitDescriptor();
 
         DeployitNotifier notifierSpy = spy(new DeployitNotifier("AdminGlobal1", "app1", null, null, null, null, false, null, overridingCredentialProvided));


### PR DESCRIPTION
* Added Authentication Type (BASIC/PAT) to the credential configuration UI
* Split inline secrets into password (BASIC) and patToken (PAT) to prevent Stapler array binding issues
* Added dynamic Jelly/JavaScript toggling so BASIC showed username+password and PAT showed token only
* Passed authType through validation endpoints and applied auth-specific validation rules
* Supported PAT stored credentials via Secret Text and BASIC via Username/Password
* Enforced credential-type checks in runtime notifier credential resolution
* Added helper methods for token extraction and generic IdCredentials lookup
* Updated credential construction paths for the new PAT token parameter
